### PR TITLE
Feature/proptypes small fixes

### DIFF
--- a/src/components/AboutPage/About.js
+++ b/src/components/AboutPage/About.js
@@ -2,8 +2,9 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import './About.css';
 import myPhoto from '../../assets/myPhoto.png';
+import PropTypes from 'prop-types';
 
-const AboutPage = ({charities, setLoading}) => {
+const AboutPage = ({charities}) => {
 
   const renderBackToCharitiesBtn = () => {
     if (charities.length > 0) {
@@ -41,3 +42,7 @@ const AboutPage = ({charities, setLoading}) => {
 }
 
 export default AboutPage;
+
+AboutPage.propTypes = {
+  charities: PropTypes.array
+}

--- a/src/components/AboutPage/About.js
+++ b/src/components/AboutPage/About.js
@@ -4,13 +4,13 @@ import './About.css';
 import myPhoto from '../../assets/myPhoto.png';
 import PropTypes from 'prop-types';
 
-const AboutPage = ({charities}) => {
+const AboutPage = ({charities, clearError}) => {
 
   const renderBackToCharitiesBtn = () => {
     if (charities.length > 0) {
       return (
         <Link to='/dashboard'>
-          <button className='to-dashboard-page-btn'>Back to Previously Searched Charities</button>
+          <button className='to-dashboard-page-btn' onClick={clearError}>Back to Previously Searched Charities</button>
         </Link>
       )
     }
@@ -33,7 +33,7 @@ const AboutPage = ({charities}) => {
       </article>
       <div className='btns-container'>
         <Link to='/'>
-          <button className='to-landing-page-btn'>Back to Charity Search</button>
+          <button className='to-landing-page-btn' onClick={clearError}>Back to Charity Search</button>
         </Link>
         {renderBackToCharitiesBtn()}
       </div>
@@ -44,5 +44,6 @@ const AboutPage = ({charities}) => {
 export default AboutPage;
 
 AboutPage.propTypes = {
-  charities: PropTypes.array
+  charities: PropTypes.array,
+  clearError: PropTypes.func
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -58,7 +58,7 @@ const App = () => {
         <Route
           exact path='/about'
           render={() => {
-            return < AboutPage charities={charities} />
+            return < AboutPage charities={charities} clearError={clearError}/>
           }}
         />
         <Route

--- a/src/components/CharityCard/CharityCard.js
+++ b/src/components/CharityCard/CharityCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './CharityCard.css';
+import PropTypes from 'prop-types';
 
 const CharityCard = ({charity}) => {
 
@@ -25,3 +26,7 @@ const CharityCard = ({charity}) => {
 }
 
 export default CharityCard;
+
+CharityCard.propTypes = {
+  charity: PropTypes.object
+}

--- a/src/components/CharityContainer/CharityContainer.js
+++ b/src/components/CharityContainer/CharityContainer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import CharityCard from '../CharityCard/CharityCard.js';
 import './CharityContainer.css';
+import PropTypes from 'prop-types';
 
 const CharityContainer = ({charities}) => {
 
@@ -16,3 +17,7 @@ const CharityContainer = ({charities}) => {
 }
 
 export default CharityContainer;
+
+CharityContainer.propTypes = {
+  charities: PropTypes.array
+}

--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import LandingPageForm from '../LandingPageForm/LandingPageForm.js';
 import './LandingPage.css';
+import PropTypes from 'prop-types';
 
 const LandingPage = ({fetchCharitiesByCategory, error, clearError}) => {
   return (
@@ -27,3 +28,9 @@ const LandingPage = ({fetchCharitiesByCategory, error, clearError}) => {
 }
 
 export default LandingPage;
+
+LandingPage.propTypes = {
+  fetchCharitiesByCategory: PropTypes.func,
+  error: PropTypes.string,
+  clearError: PropTypes.func
+}

--- a/src/components/LandingPageForm/LandingPageForm.js
+++ b/src/components/LandingPageForm/LandingPageForm.js
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react';
 import {Link} from 'react-router-dom';
 import {categoryData, stateData} from '../../stateAndCategoryData.js';
 import './LandingPageForm.css';
+import PropTypes from 'prop-types';
 
 const LandingPageForm = ({fetchCharitiesByCategory, error, clearError}) => {
   const [category, setCategory] = useState('');
@@ -77,5 +78,8 @@ const LandingPageForm = ({fetchCharitiesByCategory, error, clearError}) => {
 
 export default LandingPageForm;
 
-// <option value="volvo">Volvo</option> need this for each state/category
-// onChange events for all selects
+LandingPageForm.propTypes = {
+  fetchCharitiesByCategory: PropTypes.func,
+  error: PropTypes.string,
+  clearError: PropTypes.func
+}

--- a/src/components/MainDashboard/MainDashboard.js
+++ b/src/components/MainDashboard/MainDashboard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import CharityContainer from '../CharityContainer/CharityContainer.js';
 import './MainDashboard.css';
-
+import PropTypes from 'prop-types';
 
 const MainDashboard = ({charities}) => {
   return (
@@ -27,3 +27,7 @@ const MainDashboard = ({charities}) => {
 }
 
 export default MainDashboard;
+
+MainDashboard.propTypes = {
+  charities: PropTypes.array
+}

--- a/src/components/NotFoundPage/NotFoundPage.css
+++ b/src/components/NotFoundPage/NotFoundPage.css
@@ -1,0 +1,3 @@
+.not-found-container {
+  text-align: center;
+}

--- a/src/components/NotFoundPage/NotFoundPage.js
+++ b/src/components/NotFoundPage/NotFoundPage.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
+import './NotFoundPage.css';
 
 const NotFoundPage = () => {
   return (
-    <>
+    <div className='not-found-container'>
       <h1 className='header'>Sorry! This page does not exist!</h1>
       <p className='description'>The page that you are trying to visit does not exist for this site! Click the button below to go to the landing page.</p>
       <p className='description'>DONATE LOCALLY!</p>
       <Link to='/'>
         <button className='landing-page-btn'>Go To Landing Page</button>
       </Link>
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
### Is this a fix or a feature?
- This is a feature that adds all component's `propTypes` to the bottom of their files, as well as some small fixes like styling the 404 page for the website, as well as removing the error message on the landing page when navigating back from the About page.

### What is the change/fix?
- The change is the added `propTypes` to necessary components, small changes in `NotFoundPage.css`, and the passing of the method that clears our error message in `App.js` as a prop to the `AboutPage` component so that the error message does not persist while navigating through the app.

### Where should the reviewer start?
- The reviewer should start in `App.js` to review the passing of our error cleaning method to the `AboutPage` component. 

### How should this be tested?
- This should be tested by opening up the application and doing a viable search for charities, then go back to the landing page from the dashboard and do an incorrect search for charities. From there, go to the about page, then go back to the landing page. There should be no error persisting in the form.